### PR TITLE
Update POM to use Sonatype's Central Portal for Maven Releases

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <organization>
         <name>LYRASIS</name>
-        <url>http://www.dspace.org</url>
+        <url>https://www.dspace.org</url>
     </organization>
 
     <properties>
@@ -110,15 +110,15 @@
                 </plugin>
                 <!-- Used to generate a new release via Sonatype (see release profile). -->
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.13</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.8.0</version>
                 </plugin>
                 <!-- Used to generate JavaDocs for new releases (see release profile). -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>3.6.3</version>
+                    <version>3.11.2</version>
                     <configuration>
                         <!-- Never fail a build based on Javadoc errors -->
                         <failOnError>false</failOnError>
@@ -128,13 +128,13 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <!-- Used to sign new releases via GPG (see release profile). -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
-                    <version>3.2.1</version>
+                    <version>3.2.7</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -142,7 +142,7 @@
             <!-- Specify our settings for new releases via 'mvn release:*' -->
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.1.1</version>
                 <configuration>
                     <!-- During release:prepare and release:perform, pass the "release" property to enable the
                      "release" profile (and enable/disable other profiles based on whether they need releasing) -->
@@ -238,7 +238,7 @@
 
         <!--
          The 'release' profile is used by the 'maven-release-plugin' (see above)
-         to actually perform a DSpace lang packs release to Maven central.
+         to actually perform a DSpace lang packs release to Maven Central.
          This profile contains settings which are ONLY enabled when performing
          a DSpace release. See alse https://wiki.duraspace.org/display/DSPACE/Release+Procedure
         -->
@@ -253,26 +253,24 @@
             </activation>
             <build>
                 <plugins>
-                    <!-- Configure Nexus plugin for new releases via Sonatype.
-                         See: http://central.sonatype.org/pages/apache-maven.html -->
+                    <!--
+                      Configure Central Publishing Plugin for new releases via Sonatype.
+                      See: https://central.sonatype.org/publish/publish-portal-maven/
+                      A few notes on how this plugin works:
+                      1. In your settings.xml, your user/password tokens MUST be specified for a <server> tag
+                         with <id>central</id>. Otherwise, you will see a 401 Unauthorized error.
+                      2. The <distributionManagement> POM section is no longer needed. This plugin defaults to
+                         uploading releases to Central Portal (https://central.sonatype.com/publishing)
+                         and -SNAPSHOT releases to https://central.sonatype.com/repository/maven-snapshots/
+                      3. Sonatype has publishing *requirements* which must be met. Our POM is already configured to
+                         meet those requirements: https://central.sonatype.org/publish/requirements/
+                    -->
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                         <extensions>true</extensions>
-                        <configuration>
-                            <!-- In your settings.xml, your username/password
-                                 MUST be specified for server 'ossrh' -->
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <!-- Disable autoclose of repository after upload, as this sometimes times out -->
-                            <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
-                            <!-- Require manual verification / release to Maven Central -->
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                            <!-- Increase Staging timeout to 10mins -->
-                            <stagingProgressTimeoutMinutes>10</stagingProgressTimeoutMinutes>
-                        </configuration>
                     </plugin>
-                    <!-- For new releases, generate Source JAR files -->
+                    <!-- Per Sonatype publishing requirements, generate Source JAR files -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
@@ -285,8 +283,8 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <!-- Sign any new releases via GPG.
-                         NOTE: you may optionall specify the "gpg.passphrase" in your settings.xml -->
+                    <!-- Per Sonatype publishing requirements, sign any new releases via GPG.
+                         NOTE: you may optionally specify the "gpg.passphrase" in your settings.xml -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
@@ -333,22 +331,9 @@
     <scm>
         <connection>scm:git:git@github.com:DSpace/dspace-api-lang.git</connection>
         <developerConnection>scm:git:git@github.com:DSpace/dspace-api-lang.git</developerConnection>
-        <url>git@github.com:DSpace/dspace-api-lang.git</url>
+        <url>https://github.com/DSpace/dspace-api-lang</url>
         <tag>HEAD</tag>
     </scm>
-
-    <!-- Configure our release repositories to use Sonatype.
-         See: http://central.sonatype.org/pages/apache-maven.html -->
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
     <licenses>
         <license>


### PR DESCRIPTION
# References
This PR is a port of https://github.com/DSpace/DSpace/pull/10986 , specific to `DSpace/dspace-replicate`.

# Description
As of June 30, 2025, Sonatype has retired their older OSSRH system used to release Maven modules to Maven Central. The replacement is their new "Central Portal"

https://central.sonatype.org/pages/ossrh-eol/

This PR updates our Parent POM to use the new Central Portal for releases, following their documented guidelines: https://central.sonatype.org/publish/publish-portal-guide/

**See https://github.com/DSpace/DSpace/pull/10986 for more details.**


**WARNING: This is untested, but the only way to fully test it is to "cut" a new release.** I have tested this code in several `-SNAPSHOT` releases of `DSpace/DSpace` though and it has worked well.  Release procedure has also been updated: https://wiki.lyrasis.org/display/DSPACE/Release+Procedure